### PR TITLE
Define locale for format of expires string

### DIFF
--- a/Transloadit/Classes/TransloaditExecutor.swift
+++ b/Transloadit/Classes/TransloaditExecutor.swift
@@ -30,8 +30,13 @@ class TransloaditExecutor: TUSDelegate {
         }
         
         let formatter: DateFormatter = DateFormatter()
-        formatter.dateFormat = "YYYY/MM/dd HH:mm:s+00:00"
+        // The locale and time zone are fixed to allow reproducible conversions,
+        // independent of the locale and time setting on the user's device.
+        // As recommend in the 'Working With Fixed Format Date Representations' section on
+        // https://developer.apple.com/documentation/foundation/dateformatter
+        formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.timeZone = TimeZone(abbreviation: "UTC")
+        formatter.dateFormat = "YYYY/MM/dd HH:mm:ss+00:00"
         let dateTime: String = formatter.string(from: Date().addingTimeInterval(300))
         let authObject = ["key": KEY, "expires": dateTime]
         


### PR DESCRIPTION
A customer reported that on some devices the `expires` string is in the format 2021/07/19 08:03:07AM+00:00. The AM part not accepted by Transloadit's API. The customer also said that setting the device's time format to 24hrs fixed this problem. This patch attempts to fix this by setting a concrete locale.

This patch has not been tests as I currently do not have access to a testing device or simulator.

Ref: https://app.intercom.com/a/apps/qiqpfgjg/inbox/inbox/230775/conversations/26852700003272