### PR TITLE
Rename heading: Installation -> Install

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An **iOS** and **macOS** integration for [Transloadit](https://transloadit.com)'s file uploading and encoding service
 
-## Installation
+## Install
 
 ### CocoaPods
 


### PR DESCRIPTION
Renaming the `Installation` heading for proper automatic importing to Transloadit Docs, and for consistency.

<img width="243" alt="image" src="https://user-images.githubusercontent.com/375537/165518145-bfd20f2b-21d4-4c46-9b69-850447ace451.png">
