### PR TITLE
Don't use deprecated TUSClient initializer

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/tus/TUSKit",
         "state": {
           "branch": null,
-          "revision": "cc587003c47dc9f6a204d9aa221bc73cf61e43e1",
-          "version": "3.1.5"
+          "revision": "03d4421a6165a48f8fc1cda785ff30274e06370c",
+          "version": "3.3.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(name: "TUSKit", url: "https://github.com/tus/TUSKit", from: "3.1.5")
+        .package(name: "TUSKit", url: "https://github.com/tus/TUSKit", from: "3.3.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/TransloaditKit/Transloadit.swift
+++ b/Sources/TransloaditKit/Transloadit.swift
@@ -61,7 +61,7 @@ public final class Transloadit {
     }
     
     lazy var tusClient: TUSClient = {
-        let tusClient = try! TUSClient(server: URL(string:"https://www.transloadit.com")!, sessionIdentifier: "TransloadIt", storageDirectory: storageDir, session: session)
+        let tusClient = try! TUSClient(server: URL(string:"https://www.transloadit.com")!, sessionIdentifier: "TransloadIt", sessionConfiguration: session.configuration, storageDirectory: storageDir)
         tusClient.delegate = self
         return tusClient
     }()


### PR DESCRIPTION
Using the deprecated initializer that takes a URLSession leads to TUSKit _not_ registering its URLSessionDelegate.

See: https://github.com/tus/TUSKit/blob/main/Sources/TUSKit/TUSAPI.swift#L43-L51

By not registering its delegate, API calls never return because their callbacks are never called.