### PR TITLE
Replace Slack notification action and harden action refs

### DIFF
--- a/.github/workflows/transloaditkit-ci.yml
+++ b/.github/workflows/transloaditkit-ci.yml
@@ -9,7 +9,7 @@ jobs:
         run: echo "BRANCH=$(echo ${GITHUB_REF##*/})" >> $GITHUB_ENV
       - name: Get swift version
         run: swift --version
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Build
         run: swift build
       - name: Run tests

--- a/.github/workflows/transloaditkit-ci.yml
+++ b/.github/workflows/transloaditkit-ci.yml
@@ -14,9 +14,13 @@ jobs:
         run: swift build
       - name: Run tests
         run: swift test
-      - uses: 8398a7/action-slack@v3
+      - name: Send Slack notification
         if: failure() && env.BRANCH == 'main'
-        with:
-          status: failure
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_TEXT: >-
+            ${{ github.workflow }} failed for ${{ github.repository }} on ${{ github.ref_name }}:
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          node -e "process.stdout.write(JSON.stringify({ text: process.env.SLACK_TEXT }))" |
+            curl --fail-with-body -X POST -H 'Content-type: application/json' --data-binary @- "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
Why

Reduce GitHub Actions supply-chain exposure by removing the third-party Slack notification action from the CI failure path.

What changed

- Replaces `8398a7/action-slack` with a direct incoming-webhook `curl` step.
- Keeps the existing failure-only Slack condition.

Validation

- Ruby YAML parse for `.github/workflows/transloaditkit-ci.yml`
- `git diff --check`

Additional action reference hardening included here:

- Updates GitHub-owned actions in touched workflows to current major tags.
- Pins retained third-party actions in touched workflows to reviewed commit SHAs, keeping version comments beside each SHA.
